### PR TITLE
Update CreatioClient with NTLM authentication support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,9 @@ bld/
 # Visual Studo Code assets directory
 .vscode/
 
+# Rider assets directory
+.idea/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*
@@ -196,5 +199,3 @@ FakesAssemblies/
 
 # Node.js Tools for Visual Studio
 .ntvs_analysis.dat
-
-**/.idea

--- a/README.md
+++ b/README.md
@@ -1,17 +1,46 @@
-# creatio.client
-Easy connector .net standard connector for creatio
+# Introduction
+Creatio Client is a user-friendly connector for Creatio, implemented using **.NET Standard 2.0**
+It provides convenient methods for calling various Creatio services and subscribing to WebSocket messages.
 
-For call creatio configuration service from you application just write code:
+## Installation
+Use [NuGet](https://www.nuget.org/packages/creatio.client) to install Creatio Client
+```
+dotnet add package creatio.client
+```
+
+## Initialization
+
+You can initialize CreatioClient in three(3) different ways
+
+- Use [Cookie-based authentication](https://academy.creatio.com/docs/8.x/dev/development-on-creatio-platform/integrations-and-api/authentication/authentication-basics/overview-authentication)
+    ```csharp
+    var client = new CreatioClient(<AppUrl>, <UserName>, <UserPassword>);
+    ```
+
+- Use [OAuth 2.0](https://academy.creatio.com/docs/8.x/dev/development-on-creatio-platform/integrations-and-api/authentication/oauth-2-0-authorization/identity-service-overview)
+    ```csharp
+   var client = new CreatioClient(<AppUrl>, <ClientId>, <ClientSecret>, <UserName>, <UserPassword>);
+    ```
+
+- Use [NTLM user authentication](https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-security/ntlm-user-authentication)
+    ```csharp
+    string appUrl = "https://someName. creatio. com";
+    CreatioClient client = new(appUrl, true, CredentialCache. DefaultNetworkCredentials);
+    ```
+
+## Usage
+To call creatio configuration service from your application, use this example:
 ```
 var client = new CreatioClient(<AppUrl>, <UserName>, <UserPassword>);
 string request = client.CallConfigurationService(<ServiceName>, <MethodName>, <RequestData>);
 ```
 
-For call any creatio enpoint you can Get request:
+To execute GET request:
 ```
 string data = client.ExecuteGetRequest(<Url>);
 ```
-or POST:
+
+To execute POST request:
 ```
 string data = client.ExecutePostRequest(<Url>, <RequestData>);
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ dotnet add package creatio.client
 
 You can initialize CreatioClient in three(3) different ways
 
-- Use [Cookie-based authentication](https://academy.creatio.com/docs/8.x/dev/development-on-creatio-platform/integrations-and-api/authentication/authentication-basics/overview-authentication)
+- Use [Cookie-based authentication](https://academy.creatio.com/docs/8.x/dev/development-on-creatio-platform/integrations-and-api/authentication/authentication-basics/overview)
     ```csharp
     var client = new CreatioClient(<AppUrl>, <UserName>, <UserPassword>);
     ```

--- a/creatioclient.example/Program.cs
+++ b/creatioclient.example/Program.cs
@@ -12,17 +12,16 @@ public static class Program
 
 	#region Methods: Private
 
-	private static void Main(string[] args){
+	
+	private const string AppUrl = "http://kkrylovn.tscrm.com:40016";
+	
+	private static void Main(){
 		
 		const string username = "Supervisor";
 		const string password = "Supervisor";
 		const string logFile = "C:\\ws.json";
 		
-		// const string app = "http://ts1-mrkt-web01.tscrm.com:91/zoominfo_staging";
-		// CreatioClient client = new(app, username, password, true, false);
-		
-		const string app = "http://kkrylovn.tscrm.com:40016";
-		CreatioClient client = new(app, username, password, true, true);
+		CreatioClient client = new(AppUrl, username, password, true, true);
 		
 		client.ConnectionStateChanged += (sender, state) => {
 			Console.WriteLine($"Connection state changed to: {state}");
@@ -41,6 +40,13 @@ public static class Program
 		};
 		client.StartListening(CancellationToken.None);
 		Console.ReadLine();
+	}
+	
+	private static void Example2(){
+		CreatioClient client = new(AppUrl, true, CredentialCache.DefaultNetworkCredentials);
+		const string url = AppUrl+ "/0/ServiceModel/UserInfoService.svc/getCurrentUserInfo";
+		string result = client.ExecutePostRequest(url, string.Empty, 100000);
+		Console.WriteLine(result);
 	}
 
 	#endregion

--- a/creatioclient.example/Program.cs
+++ b/creatioclient.example/Program.cs
@@ -13,7 +13,7 @@ public static class Program
 	#region Methods: Private
 
 	
-	private const string AppUrl = "http://kkrylovn.tscrm.com:40016";
+	private const string AppUrl = "http://some-site.creatio.com";
 	
 	private static void Main(){
 		

--- a/creatioclient/ICreatioClient.cs
+++ b/creatioclient/ICreatioClient.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Net.WebSockets;
+using System.Threading;
+using Creatio.Client.Dto;
+
+namespace Creatio.Client
+{
+	public interface ICreatioClient
+	{
+
+		#region Events: Public
+
+		event EventHandler<WsMessage> MessageReceived;
+
+		event EventHandler<WebSocketState> ConnectionStateChanged;
+
+		#endregion
+
+		#region Methods: Public
+
+		/// <summary>
+		/// Calls a configuration service in the Creatio application.
+		/// </summary>
+		/// <param name="serviceName">The name of the service to call.</param>
+		/// <param name="serviceMethod">The method of the service to call.</param>
+		/// <param name="requestData">The data to send with the request.</param>
+		/// <param name="requestTimeout">Optional. The timeout for the request in milliseconds. Default is 100000.</param>
+		/// <returns>The response from the service as a string.</returns>
+		string CallConfigurationService(string serviceName, string serviceMethod, string requestData,
+			int requestTimeout = 100000);
+
+		/// <summary>
+		/// Downloads a file from the specified URL and saves it to the provided file path.
+		/// </summary>
+		/// <param name="url">The URL of the file to download.</param>
+		/// <param name="filePath">The path where the downloaded file should be saved.</param>
+		/// <param name="requestData">The data to send with the request.</param>
+		/// <param name="requestTimeout">Optional. The timeout for the request in milliseconds. Default is 100000.</param>
+		void DownloadFile(string url, string filePath, string requestData, int requestTimeout = 100000);
+
+		/// <summary>
+		/// Executes a GET request to the specified URL.
+		/// </summary>
+		/// <param name="url">The URL to send the GET request to.</param>
+		/// <param name="requestTimeout">Optional. The timeout for the request in milliseconds. Default is 100000.</param>
+		/// <param name="retryCount">Optional. The number of times to retry the request in case of failure. Default is 1.</param>
+		/// <param name="delaySec">Optional. The delay in seconds before retrying the request. Default is 1.</param>
+		/// <returns>The response from the GET request as a string.</returns>
+		string ExecuteGetRequest(string url, int requestTimeout = 100000, int retryCount = 1, int delaySec = 1);
+
+		
+		/// <summary>
+		/// Executes a POST request to the specified URL.
+		/// </summary>
+		/// <param name="url">The URL to send the POST request to.</param>
+		/// <param name="requestData">The data to send with the request.</param>
+		/// <param name="requestTimeout">Optional. The timeout for the request in milliseconds. Default is 100000.</param>
+		/// <param name="retryCount">Optional. The number of times to retry the request in case of failure. Default is 1.</param>
+		/// <param name="delaySec">Optional. The delay in seconds before retrying the request. Default is 1.</param>
+		/// <returns>The response from the POST request as a string.</returns>
+		string ExecutePostRequest(string url, string requestData, int requestTimeout = 100000, int retryCount = 1, int delaySec = 1);
+
+		/// <summary>
+		/// Logs in to the Creatio application.
+		/// </summary>
+		void Login();
+		
+		/// <summary>
+		/// Uploads a file to the Application Lifecycle Management (ALM) system.
+		/// </summary>
+		/// <param name="url">The URL of the ALM system to upload the file to.</param>
+		/// <param name="filePath">The path of the file to be uploaded.</param>
+		/// <returns>The response from the ALM system as a string.</returns>
+		string UploadAlmFile(string url, string filePath);
+
+		/// <summary>
+		/// Uploads a file to the specified URL.
+		/// </summary>
+		/// <param name="url">The URL to upload the file to.</param>
+		/// <param name="filePath">The path of the file to be uploaded.</param>
+		/// <param name="requestTimeout">Optional. The timeout for the request in milliseconds. Default is 100000.</param>
+		/// <returns>The response from the server as a string.</returns>
+		string UploadFile(string url, string filePath, int requestTimeout = 100000);
+
+		/// <summary>
+		/// Starts listening for incoming messages from the Creatio application.
+		/// </summary>
+		/// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
+		void StartListening(CancellationToken cancellationToken);
+
+		/// <summary>
+		/// Sets a custom retry policy for HTTP calls.
+		/// </summary>
+		/// <param name="retryCount">The number of times to retry the HTTP call in case of failure.</param>
+		/// <param name="delaySec">The delay in seconds before retrying the HTTP call.</param>
+		/// <param name="retryPolicy">The retry policy to use for the HTTP call. See <see cref="RetryPolicy"/>.</param>
+		void SetRetryPolicy(int retryCount, int delaySec, RetryPolicy retryPolicy);
+
+		#endregion
+
+	}
+}

--- a/creatioclient/creatioclient.csproj
+++ b/creatioclient/creatioclient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Description>.net client for call creatio api in simple way (.net standart campatible)</Description>
+    <Description>.net client to call creatio api in simple way (.net standart campatible)</Description>
     <Authors>a.technologies.foundation@gmail.com</Authors>
     <Company>ATF</Company>
     <PackageId>creatio.client</PackageId>
@@ -10,14 +10,14 @@
     <AssemblyName>Creatio.Client</AssemblyName>
     <RootNamespace>Creatio.Client</RootNamespace>
     <RepositoryUrl>https://github.com/Advance-Technologies-Foundation/creatioclient</RepositoryUrl>
-    <AssemblyVersion>1.0.23</AssemblyVersion>
+    <AssemblyVersion>1.0.24</AssemblyVersion>
     <FileVersion>$(AssemblyVersion)</FileVersion>
     <Version>$(AssemblyVersion)</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The CreatioClient now has optional support for NTLM authentication. The README file was also updated with documentation, including the new authentication method.