### PR TITLE
feat: add DownloadFileByGet for binary GET-to-file downloads

### DIFF
--- a/creatioclient/CreatioClient.cs
+++ b/creatioclient/CreatioClient.cs
@@ -461,6 +461,14 @@ namespace Creatio.Client
 			request.SaveToFile(filePath);
 		}
 
+		public void DownloadFileByGet(string url, string filePath, int requestTimeout = 100000) {
+			Retry<bool>(() => {
+				HttpWebRequest request = CreateCreatioRequest(url, null, requestTimeout, "GET");
+				request.SaveToFile(filePath);
+				return true;
+			}, _retryCount, _delaySec, _retryPolicy);
+		}
+
 		public string ExecuteGetRequest(string url, int requestTimeout = 100000, int retryCount = 1, int delaySec = 1) {
 			return Retry<string>(() => {
 				HttpWebRequest request = CreateCreatioRequest(url, null, requestTimeout);

--- a/creatioclient/ICreatioClient.cs
+++ b/creatioclient/ICreatioClient.cs
@@ -40,6 +40,16 @@ namespace Creatio.Client
 		void DownloadFile(string url, string filePath, string requestData, int requestTimeout = 100_000);
 
 		/// <summary>
+		/// Downloads a file via an HTTP GET request to the specified URL and saves it to disk,
+		/// preserving binary content. Use this for GET-only file endpoints (e.g. OData media links
+		/// or [WebGet] services) where <see cref="DownloadFile"/> (which issues a POST) is unsuitable.
+		/// </summary>
+		/// <param name="url">The absolute URL of the file to download.</param>
+		/// <param name="filePath">The path where the downloaded file should be saved.</param>
+		/// <param name="requestTimeout">Optional. The timeout for the request in milliseconds. Default is 100000.</param>
+		void DownloadFileByGet(string url, string filePath, int requestTimeout = 100_000);
+
+		/// <summary>
 		/// Executes a GET request to the specified URL.
 		/// </summary>
 		/// <param name="url">The URL to send the GET request to.</param>


### PR DESCRIPTION
## Summary
Adds a public `DownloadFileByGet(url, filePath, requestTimeout)` to `CreatioClient` / `ICreatioClient`. It issues an authenticated HTTP **GET** and streams the response to disk via `SaveToFile`, preserving binary content.

## Why
There is currently no public way to download a file over an arbitrary GET URL:
- `DownloadFile` issues a **POST** (returns 405 on `[WebGet]` / OData media-link endpoints).
- `ExecuteGetRequest` returns a `string` (corrupts binary payloads).

The new method generalizes the existing `DownloadAttachment` GET-to-file path (`CreateCreatioRequest(url, null, timeout, "GET").SaveToFile(...)`) to an arbitrary URL.

## Use case
Enables clio to download MS Word report templates from the `SysModuleReport(id)/File` OData media link (new `download-report-template` MCP tool). Verified end-to-end against a live Creatio stand: downloaded template is byte-identical to the upload; empty (204) stream columns are handled by the caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)