### PR TITLE
fix: rename retryCount to maxAttempts and clamp to a single attempt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,14 +105,17 @@ set to `false` when connecting to trusted production endpoints.
 
 ### Retry Policy
 
-`SetRetryPolicy(retryCount, delaySec, RetryPolicy)` configures instance-level retries for
+`SetRetryPolicy(maxAttempts, delaySec, RetryPolicy)` configures instance-level retry behaviour for
 `ExecutePostRequest`, `ExecuteGetRequest`, `ExecuteDeleteRequest`, and the chunk loop inside
 `UploadAttachmentAsync`.
 
+- The count is a **total attempt count**, not a number of retries: `maxAttempts = 1` makes a
+  single attempt with no retry. Values below 1 are clamped to 1 (a `0` never silently skips the
+  request).
 - `RetryPolicy.Simple` — fixed delay of `delaySec` seconds between attempts
 - `RetryPolicy.Progressive` — delay multiplied by attempt number (1×, 2×, 3×, …)
 
-Default: 1 retry, 1-second delay.
+Default: 1 attempt (no retries), 1-second delay.
 
 ### WebSocket Listeners
 

--- a/creatioclient/CreatioClient.cs
+++ b/creatioclient/CreatioClient.cs
@@ -35,7 +35,7 @@ namespace Creatio.Client
 		private readonly bool _useUntrustedSsl = true;
 		private CookieContainer _authCookie;
 		private string _oauthToken;
-		private int _retryCount = 1;
+		private int _maxAttempts = 1;
 		private int _delaySec = 1;
 		private RetryPolicy _retryPolicy = RetryPolicy.Simple;
 		private readonly ICredentials _credentials;
@@ -453,7 +453,7 @@ namespace Creatio.Client
 			string requestData,
 			int requestTimeout = 100000){
 			string executeUrl = CreateConfigurationServiceUrl(serviceName, serviceMethod);
-			return ExecutePostRequest(executeUrl, requestData, requestTimeout, _retryCount, _delaySec);
+			return ExecutePostRequest(executeUrl, requestData, requestTimeout, _maxAttempts, _delaySec);
 		}
 
 		public void DownloadFile(string url, string filePath, string requestData, int requestTimeout = 100000){
@@ -466,18 +466,18 @@ namespace Creatio.Client
 				HttpWebRequest request = CreateCreatioRequest(url, null, requestTimeout, "GET");
 				request.SaveToFile(filePath);
 				return true;
-			}, _retryCount, _delaySec, _retryPolicy);
+			}, _maxAttempts, _delaySec, _retryPolicy);
 		}
 
-		public string ExecuteGetRequest(string url, int requestTimeout = 100000, int retryCount = 1, int delaySec = 1) {
+		public string ExecuteGetRequest(string url, int requestTimeout = 100000, int maxAttempts = 1, int delaySec = 1) {
 			return Retry<string>(() => {
 				HttpWebRequest request = CreateCreatioRequest(url, null, requestTimeout);
 				request.Method = "GET";
 				return request.GetServiceResponse();
-			}, retryCount, delaySec, _retryPolicy);
+			}, maxAttempts, delaySec, _retryPolicy);
 		}
 
-		public string ExecutePostRequest(string url, string requestData, int requestTimeout = 10000, int retryCount = 1, int delaySec = 1){
+		public string ExecutePostRequest(string url, string requestData, int requestTimeout = 10000, int maxAttempts = 1, int delaySec = 1){
 			return Retry<string>(() => {
 				using( var handler = CreateCreatioHandler()) {
 					if (_oauthToken != null) {
@@ -500,10 +500,10 @@ namespace Creatio.Client
 						return content;
 					}
 				}
-			}, retryCount, delaySec, _retryPolicy);
+			}, maxAttempts, delaySec, _retryPolicy);
 		}
 
-			public string ExecuteDeleteRequest(string url, string requestData, int requestTimeout = 10000, int retryCount = 1, int delaySec = 1){
+			public string ExecuteDeleteRequest(string url, string requestData, int requestTimeout = 10000, int maxAttempts = 1, int delaySec = 1){
 				return Retry<string>(() => {
 					using (var handler = CreateCreatioHandler()) {
 						HttpRequestMessage BuildRequest(HttpClient client) {
@@ -530,10 +530,10 @@ namespace Creatio.Client
 							return response.Content.ReadAsStringAsync().Result;
 						}
 					}
-				}, retryCount, delaySec, _retryPolicy);
+				}, maxAttempts, delaySec, _retryPolicy);
 			}
 
-		public string ExecutePatchRequest(string url, string requestData, int requestTimeout = 10000, int retryCount = 1, int delaySec = 1){
+		public string ExecutePatchRequest(string url, string requestData, int requestTimeout = 10000, int maxAttempts = 1, int delaySec = 1){
 			return Retry<string>(() => {
 				using (var handler = CreateCreatioHandler()) {
 					// netstandard2.0 has no HttpMethod.Patch; the string ctor is the portable form.
@@ -560,21 +560,22 @@ namespace Creatio.Client
 						return response.Content.ReadAsStringAsync().Result;
 					}
 				}
-			}, retryCount, delaySec, _retryPolicy);
+			}, maxAttempts, delaySec, _retryPolicy);
 		}
 
-		static T Retry<T>(Func<T> func, int maxRetries, int delaySeconds, RetryPolicy retryPolicy = RetryPolicy.Simple) {
-			int retries = 0;
+		static T Retry<T>(Func<T> func, int maxAttempts, int delaySeconds, RetryPolicy retryPolicy = RetryPolicy.Simple) {
+			if (maxAttempts < 1) maxAttempts = 1;   // a 0/negative count must never silently skip the request
+			int attempts = 0;
 			int multiplicator = 1; 
-			while (retries < maxRetries) {
+			while (attempts < maxAttempts) {
 				try {
 					return func();
 				} catch (Exception ex) {
-					retries++;
+					attempts++;
 					if (retryPolicy == RetryPolicy.Progressive) {
 						multiplicator++;
 					} 
-					if (retries < maxRetries) {
+					if (attempts < maxAttempts) {
 						Thread.Sleep(delaySeconds * 1000 * multiplicator);
 					} else {
 						throw;					}
@@ -913,8 +914,8 @@ namespace Creatio.Client
 		}
 
 		/// <inheritdoc/>
-		public void SetRetryPolicy(int retryCount, int delaySec, RetryPolicy retryPolicy) {
-			_retryCount = retryCount;
+		public void SetRetryPolicy(int maxAttempts, int delaySec, RetryPolicy retryPolicy) {
+			_maxAttempts = maxAttempts;
 			_delaySec = delaySec;
 			_retryPolicy = retryPolicy;
 		}
@@ -943,7 +944,7 @@ namespace Creatio.Client
 							var msg = CreateUploadRequestMessage(uri, buffer, totalBytesRead - bytesRead,
 								currentChunkSize, fileStream.Length, fileName, mime);
 							return client.SendAsync(msg).Result;
-						}, _retryCount, _delaySec, _retryPolicy);
+						}, _maxAttempts, _delaySec, _retryPolicy);
 						string resultString = await response.Content.ReadAsStringAsync();
 						returnResult = resultString;
 						response.EnsureSuccessStatusCode();
@@ -969,7 +970,7 @@ namespace Creatio.Client
 			return Retry<bool>(() => {
 				request.SaveToFile(filePath);
 				return true;
-			}, _retryCount, _delaySec, _retryPolicy);
+			}, _maxAttempts, _delaySec, _retryPolicy);
 		}
 
 		#endregion

--- a/creatioclient/ICreatioClient.cs
+++ b/creatioclient/ICreatioClient.cs
@@ -54,10 +54,10 @@ namespace Creatio.Client
 		/// </summary>
 		/// <param name="url">The URL to send the GET request to.</param>
 		/// <param name="requestTimeout">Optional. The timeout for the request in milliseconds. Default is 100000.</param>
-		/// <param name="retryCount">Optional. The number of times to retry the request in case of failure. Default is 1.</param>
+		/// <param name="maxAttempts">Optional. Total number of attempts to make (minimum 1; values below 1 are treated as 1). Default is 1 (a single attempt, no retries).</param>
 		/// <param name="delaySec">Optional. The delay in seconds before retrying the request. Default is 1.</param>
 		/// <returns>The response from the GET request as a string.</returns>
-		string ExecuteGetRequest(string url, int requestTimeout = 100_000, int retryCount = 1, int delaySec = 1);
+		string ExecuteGetRequest(string url, int requestTimeout = 100_000, int maxAttempts = 1, int delaySec = 1);
 
 		
 		/// <summary>
@@ -66,10 +66,10 @@ namespace Creatio.Client
 		/// <param name="url">The URL to send the POST request to.</param>
 		/// <param name="requestData">The data to send with the request.</param>
 		/// <param name="requestTimeout">Optional. The timeout for the request in milliseconds. Default is 100000.</param>
-		/// <param name="retryCount">Optional. The number of times to retry the request in case of failure. Default is 1.</param>
+		/// <param name="maxAttempts">Optional. Total number of attempts to make (minimum 1; values below 1 are treated as 1). Default is 1 (a single attempt, no retries).</param>
 		/// <param name="delaySec">Optional. The delay in seconds before retrying the request. Default is 1.</param>
 		/// <returns>The response from the POST request as a string.</returns>
-		string ExecutePostRequest(string url, string requestData, int requestTimeout = 100_000, int retryCount = 1, int delaySec = 1);
+		string ExecutePostRequest(string url, string requestData, int requestTimeout = 100_000, int maxAttempts = 1, int delaySec = 1);
 
 		/// <summary>
 		/// Executes a PATCH request to the specified URL. Used for OData v4 partial updates,
@@ -78,10 +78,10 @@ namespace Creatio.Client
 		/// <param name="url">The URL to send the PATCH request to (typically an OData entity addressed by key, e.g. <c>odata/Contact(&lt;guid&gt;)</c>).</param>
 		/// <param name="requestData">The JSON body containing the field/value pairs to change.</param>
 		/// <param name="requestTimeout">Optional. The timeout for the request in milliseconds. Default is 100000.</param>
-		/// <param name="retryCount">Optional. The number of times to retry the request in case of failure. Default is 1.</param>
+		/// <param name="maxAttempts">Optional. Total number of attempts to make (minimum 1; values below 1 are treated as 1). Default is 1 (a single attempt, no retries).</param>
 		/// <param name="delaySec">Optional. The delay in seconds before retrying the request. Default is 1.</param>
 		/// <returns>The response from the PATCH request as a string (empty for the typical 204 No Content).</returns>
-		string ExecutePatchRequest(string url, string requestData, int requestTimeout = 100_000, int retryCount = 1, int delaySec = 1);
+		string ExecutePatchRequest(string url, string requestData, int requestTimeout = 100_000, int maxAttempts = 1, int delaySec = 1);
 
 		/// <summary>
 		/// Logs in to the Creatio application.
@@ -118,10 +118,10 @@ namespace Creatio.Client
 		/// <summary>
 		/// Sets a custom retry policy for HTTP calls.
 		/// </summary>
-		/// <param name="retryCount">The number of times to retry the HTTP call in case of failure.</param>
+		/// <param name="maxAttempts">Total number of attempts to make for the HTTP call (minimum 1; values below 1 are treated as 1).</param>
 		/// <param name="delaySec">The delay in seconds before retrying the HTTP call.</param>
 		/// <param name="retryPolicy">The retry policy to use for the HTTP call. See <see cref="RetryPolicy"/>.</param>
-		void SetRetryPolicy(int retryCount, int delaySec, RetryPolicy retryPolicy);
+		void SetRetryPolicy(int maxAttempts, int delaySec, RetryPolicy retryPolicy);
 
 		/// <summary>
 		/// Uploads an attachment to a Creatio entity.


### PR DESCRIPTION
## What & why

clio's schema-publish call passed `retryCount: 0` expecting **one request, no retries** — but **we expected 1 request and got 0**: the request was never sent. `Creatio.Client`'s `Retry<T>` treated the parameter as a *total attempt count*, not a number of retries (`while (retries < maxRetries)` counts the first call too), so `0` meant *zero attempts* → the method returned `null` → the caller hit a `NullReferenceException` while parsing the (null) response. The name `retryCount` was misleading: `1` already meant a single attempt with no retry.

Jira: https://creatio.atlassian.net/browse/ENG-91470

## Changes

- Rename the public `retryCount` parameter to `maxAttempts` so the name matches the real behaviour (total attempts, not extra retries) — on `ExecuteGetRequest` / `ExecutePostRequest` / `ExecuteDeleteRequest` / `ExecutePatchRequest` and `SetRetryPolicy`, the private `_retryCount` field, and the `ICreatioClient` interface.
- Clamp `maxAttempts < 1` to `1` in `Retry<T>` so a `0` or negative count can never silently skip the request and return `null`.
- Update XML doc comments and `CLAUDE.md`. Behaviour is unchanged for any value `>= 1`.

## Compatibility & release

- Source-breaking for callers using the named argument `retryCount:`. Intended release: **minor `1.1.0`** (with a release note).
- A matching change set in **clio** adopts this API (renames its own retry/attempt vocabulary to `maxAttempts`, passes `maxAttempts: 1` for the non-idempotent publish call) and will bump its `creatio.client` pin to `1.1.0` after this is published.

## Testing

- `dotnet build` (Release) clean.
- Verified end-to-end against a Creatio stand: the buggy build → publish fails with the `null`/NRE; this build → publish issues exactly one request and succeeds, schema immediately usable, no extra compile.